### PR TITLE
docs: improve readability

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,14 @@
--   id: typos
-    name: typos
-    description: 'Source code spell checker, binary install'
-    entry: typos
-    language: python
-    'types': [text]
-    args: ["--write-changes", "--force-exclude"]
-    require_serial: false
-    additional_dependencies: []
-    minimum_pre_commit_version: '0'
+---
+- id: typos
+  name: typos
+  description: Source code spell checker, binary install
+  entry: typos
+  language: python
+  types:
+    - text
+  args:
+    - --write-changes
+    - --force-exclude
+  require_serial: false
+  additional_dependencies: []
+  minimum_pre_commit_version: "0"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,14 +1,10 @@
----
-- id: typos
-  name: typos
-  description: Source code spell checker, binary install
-  entry: typos
-  language: python
-  types:
-    - text
-  args:
-    - --write-changes
-    - --force-exclude
-  require_serial: false
-  additional_dependencies: []
-  minimum_pre_commit_version: "0"
+-   id: typos
+    name: typos
+    description: 'Source code spell checker, binary install'
+    entry: typos
+    language: python
+    'types': [text]
+    args: ["--write-changes", "--force-exclude"]
+    require_serial: false
+    additional_dependencies: []
+    minimum_pre_commit_version: '0'

--- a/README.md
+++ b/README.md
@@ -2,25 +2,41 @@
 
 Mirror of [typos](https://github.com/crate-ci/typos) for pre-commit.
 
-## Background
+## Why use this mirror?
 
-`.pre-commit-config.yaml` is included in repo but uses tagging strategy tags `v1`, semantic release tag and subpackage tag. This does not interact well `pre-commit autoupdate` as `v1` is a mutable tag. This repos mirrors tags filtering by `v1.*` so only semantic release tags are fetched.
+The original `typos` repository uses multiple tagging strategies:
 
-See [here](https://github.com/crate-ci/typos/issues/390) for discussion in repo.
+- A mutable `v1` tag
+- Semantic release tags (e.g., `v1.3.3`)
+- Subpackage tags (e.g., `typos-v0.8.2`)
+
+When using `pre-commit autoupdate`, this causes confusion because pre-commit's autoupdate can switch between different project tags in the same repository. For example, it might incorrectly update from `v1.3.1` to `typos-v0.8.2` instead of the latest semantic release like `v1.3.3`.
+
+This mirror repository solves this problem by filtering and only mirroring `v1.*` semantic release tags, ensuring `pre-commit autoupdate` works correctly and always updates to the proper semantic version.
+
+See [GitHub issue #390](https://github.com/crate-ci/typos/issues/390) for the original discussion.
 
 ## Usage
+
+Add this to your `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
   - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.31.0
+    rev: v1.42.0  # Use the latest version from the releases page
     hooks:
       - id: typos
 ```
 
-This can be configured based on usage guide in source repo.
+To find the latest version, check the [releases page](https://github.com/adhtruong/mirrors-typos/releases) or run `pre-commit autoupdate` which will automatically update to the latest available version.
 
-### Differences with typos pre-commit
+For additional configuration options, refer to the [typos documentation](https://github.com/crate-ci/typos).
 
-- Only `typos` from binary is supported.
-- Stages not specified. This is not supported by tool to generate this repo.
+## Differences from typos pre-commit
+
+- **Only binary installation**: Only the `typos` binary is supported (no additional stages configuration)
+- **Simplified hook configuration**: The `stages` parameter is not specified in the hook definition, as this is not supported by the mirror generation tool
+
+## Maintenance
+
+This mirror is automatically maintained via GitHub Actions. The workflow runs daily and on pushes to the main branch, using [pre-commit-mirror-maker](https://github.com/pre-commit/pre-commit-mirror-maker) to sync only `v1.*` semantic release tags from the upstream repository.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For additional configuration options, refer to the [typos documentation](https:/
 ## Differences from typos pre-commit
 
 - **Only binary installation**: Only the `typos` binary is supported
-- **Simplified hook configuration**: The `stages` parameter is not specified in the hook definition, as this is not supported by the mirror generation tool
+- **Different hook configuration**: The `stages` parameter is not specified in the hook definition, as this is not supported by the mirror generation tool
 
 ## Maintenance
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For additional configuration options, refer to the [typos documentation](https:/
 
 ## Differences from typos pre-commit
 
-- **Only binary installation**: Only the `typos` binary is supported (no additional stages configuration)
+- **Only binary installation**: Only the `typos` binary is supported
 - **Simplified hook configuration**: The `stages` parameter is not specified in the hook definition, as this is not supported by the mirror generation tool
 
 ## Maintenance

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.42.0  # Use the latest version from the releases page
+    rev: v1.48.0  # Use the latest version from the releases page
     hooks:
       - id: typos
 ```


### PR DESCRIPTION
This pull request updates the documentation and configuration for the `typos` pre-commit hook mirror to clarify its purpose, usage, and differences from the upstream repository. The changes aim to improve clarity for users and ensure the hook configuration is consistent and easier to maintain.

**Documentation improvements:**

* Expanded the `README.md` to explain why this mirror exists, detailing the upstream tagging strategy and how this mirror avoids issues with `pre-commit autoupdate` by only including `v1.*` semantic release tags.
* Added clear usage instructions, guidance on finding the latest version, and a summary of differences from the original `typos` pre-commit hook.
* Documented the automatic maintenance process for the mirror using GitHub Actions.

**Configuration cleanup:**

* ~~Reformatted `.pre-commit-hooks.yaml` for consistency and readability, correcting indentation and list formatting.~~ UPDATE: reverted in [85edffa](https://github.com/adhtruong/mirrors-typos/pull/2/commits/85edffaf96340db9423b91d74cc0f71178f67627) since this file is auto-generated (see [comment](https://github.com/adhtruong/mirrors-typos/pull/2#discussion_r3329981551)).

---

Thanks for making this mirror! I will be switching all my projects over to it soon.