### PR TITLE
ci: bump versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
       - run: pip install git+https://github.com/pre-commit/pre-commit-mirror-maker@v1.12.0
       - run: git config --global user.name 'Github Actions'
       - run: git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
-      - run: pip install git+https://github.com/pre-commit/pre-commit-mirror-maker@v1.12.0
+      - run: pip install git+https://github.com/pre-commit/pre-commit-mirror-maker@v1.13.1
       - run: git config --global user.name 'Github Actions'
       - run: git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     name: main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
       - run: pip install git+https://github.com/pre-commit/pre-commit-mirror-maker@v1.12.0
       - run: git config --global user.name 'Github Actions'


### PR DESCRIPTION
- checkout 6 -> 7
- setup-python 6 -> 7
- pre-commit-mirror-maker v1.12.0 -> v1.13.1

Note: This will be a recurring maintenance task until something like Dependabot or Renovatebot is configured.

Related:
- https://github.com/adhtruong/mirrors-typos/pull/3#issuecomment-4332138614
- https://github.com/adhtruong/mirrors-typos/pull/3#issuecomment-4396444735